### PR TITLE
URL for token documentation updated

### DIFF
--- a/getting-started/more-info.md
+++ b/getting-started/more-info.md
@@ -190,4 +190,4 @@ crave run --no-patch --platform aosp-silver -- "build commands here"
 
 If there are no tokens left in your wallet, the paid build will fail(but you can still use the free queue). A running build is able to go into Negative credits but no new paid builds can be requested while having less than 0 credits.
 
-[Crave doc for Wallet](https://foss.crave.io/docs/wallets)
+[Crave doc for Wallet](https://foss.crave.io/docs/wallets/)


### PR DESCRIPTION
## Why?
The documentation for the Wallets URL was pointing to a non existent page.

## Fix
Changed it to the correct URL